### PR TITLE
[#84] Fixes bug whereby elements not found on 2.01 files are not shown

### DIFF
--- a/functions/get_elements_from_schema.php
+++ b/functions/get_elements_from_schema.php
@@ -14,22 +14,37 @@ function get_elements_from_schema($schema, $version) {
 		case "activity":
 			$elements = array('iati-activity'); //We need to include this here, as it's not included in the results using the xpath below
 			$xsd = "iati-schemas/$version/iati-activities-schema.xsd";
-			$xpath = "//xsd:schema/xsd:element[@name='iati-activity']/xsd:complexType/xsd:choice/xsd:element";
+      if (intval($version) < 2) { //i.e. version 1.x
+        $xpath = "//xsd:schema/xsd:element[@name='iati-activity']/xsd:complexType/xsd:choice/xsd:element";
+      } else { //i.e. version 2.x
+        $xpath = "//xsd:schema/xsd:element[@name='iati-activity']/xsd:complexType/xsd:sequence/xsd:element";
+      }
 			break;
 		case "organisation":
 			$elements = array('iati-organisation');
 			$xsd = "iati-schemas/$version/iati-organisations-schema.xsd";
+      if (intval($version) < 2) { //i.e. version 1.x
 			$xpath = "//xsd:schema/xsd:element[@name='iati-organisation']/xsd:complexType/xsd:choice/xsd:element";
+      } else { //i.e. version 2.x
+        $xpath = "//xsd:schema/xsd:element[@name='iati-organisation']/xsd:complexType/xsd:sequence/xsd:element";
+      }
 			break;
 		default:
 			break;
 		}
+    //echo $xsd;
 	$xml = simplexml_load_file($xsd); //this is fairly safe from XXE attack as we have hardcoded links and files hopefully - trusted source?
-	//print_r($xml);
+	//print_r($xml); 
+  //var_dump($xml); die;
 	$elements = $xml->xpath($xpath);
 	foreach ($elements as $element) {
 		//echo $element->attributes()->ref .PHP_EOL;
-		$name = (string)$element->attributes()->ref;
+    if (isset($element->attributes()->ref)) {
+      $name = (string)$element->attributes()->ref;
+    } elseif (isset($element->attributes()->name)) {
+      $name = (string)$element->attributes()->name;
+    }
+    //echo $name;
 		$all_elements[] = $name;
 	}
 	/*die;

--- a/pages/found_elements.php
+++ b/pages/found_elements.php
@@ -21,7 +21,7 @@
       } else {
         $schema = "organisation";
       }
-    
+      //echo $schema; die;
       //We need to establish the version of the schema we are working with
       //Note there is a similar routine set in validate-xsd.php, but we can't rely on that being run yet
       //It might be an idea to set this globally much earlier on 
@@ -77,16 +77,19 @@
         include("functions/get_elements_from_supplied_file.php");
         //$file_path = $_SESSION['uploadedfilepath']; //Sanitise/Check this?
         
-        
+        //echo $schema;
         //Set up an array of all top level elements in the schema
         if (isset($version) && in_array($version,$iati_versions)) { //This should already be safe by now, but doesn't hurt to check
           //This should always be true at this stage, so the else is just a fallback
+          //echo "got this far"; //die;
           $all_elements = get_elements_from_schema($schema, $version);
+          //var_dump($all_elements); die;
         } else {
           $all_elements = get_elements_from_schema($schema, $current_version);
         }
-        sort($all_elements);
         //print_r($all_elements);
+        sort($all_elements);
+       
         
         //Set up an array of all the elements found in the supplied file
         $found_elements = get_elements_from_supplied_file($file_path); //this returns all elements
@@ -98,6 +101,7 @@
         } else {
           $unique_found_elements = array();
         }
+        //print_r($unique_found_elements);
         sort($unique_found_elements);
         //print_r($unique_found_elements);
            
@@ -110,6 +114,7 @@
         $elements['missing'] = $missing_elements;
         $elements['counts'] = $unique_found_elements_count;
         $elements_json = json_encode($elements);
+        //When debugging, comment this line out to stop it caching.
         file_put_contents($file_path . "_elements_" . $version . ".json",$elements_json);
         
         //decode again to use it below. !


### PR DESCRIPTION
This was because of the way the new 2.01 schema is structutred.
When we get all eleemnts from the schema we need to use different
xpath expressions for version 2.x compared to version 1.x
