### PR TITLE
Add message about error messages for lines 65536+

### DIFF
--- a/index.php
+++ b/index.php
@@ -105,6 +105,7 @@ include "header.php";
             <p>Let us test your data.</p>
             <p>Upload a file, paste some code or point us to a file on the internet and we can give you some basic information about how well the data performs against the IATI standard.</p>
             <p>Files over 10MB in size may be rejected by the application.</p>
+            <p>Errors on line number 65,536 or greater may state an incorrect line number.</p>
 					<?php endif; ?>
         </div><!--/.well -->
 


### PR DESCRIPTION
Add some sort of information about how long files may produce incorrect errors.

See Zendesk ticket 5696