### PR TITLE
Element order notice should be shown for v2.01+

### DIFF
--- a/pages/validate-xsd.php
+++ b/pages/validate-xsd.php
@@ -124,9 +124,9 @@ require_once 'functions/detect_iati_version.php';
 								<h3 class="fail">Fail</h3>
 								<div id="intext">
 									<div class="alert alert-error">This file does NOT validate against the IATI <?php echo $schema; ?> Schema (version <?php echo $version; ?>)</div>
-									
-                  <?php if ($version == "2.01") {
-                            echo '<div class="alert alert-info">NOTE: In version 2.01, order of elements in the data is enforced.<br/>If only 1 error message is reported this MAY be because the order of elements is wrong. In this case, fix the error, and then try again</div>';
+
+                  <?php if (in_array($version, array("2.01", "2.02", "2.03"))) {
+                            echo '<div class="alert alert-info">NOTE: In version '.$version.', order of elements in the data is enforced.<br/>If only 1 error message is reported this MAY be because the order of elements is wrong. In this case, fix the error, and then try again</div>';
                           }
                   ?>
                   


### PR DESCRIPTION
When validating against v2.01, users are shown the following notice:

---

> NOTE: In version 2.01, order of elements in the data is enforced.
>
> If only 1 error message is reported this MAY be because the order of elements is wrong. In this case, fix the error, and then try again

---

It isn’t shown when validating against v2.02 or v2.03. However, this information is relevant to all current 2.0x versions.

It’s tempting to generalise this to all versions >=2.01, but we probably shouldn’t assume that.

It’s probably preferable to move the array of versions for which order matters into vars.php, but for the sake of sending a clear PR, I haven’t done that here.