### PR TITLE
Add privacy notice

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -38,11 +38,12 @@
         </p>
         <div id="footer-cookie">
           <aside id="text-21" class="widget-1 widget-first widget-last widget-odd widget widget_text">
-            <h3 class="widget-title">Cookie Disclaimer</h3>			
+            <h3 class="widget-title">Cookie Disclaimer</h3>
             <div class="textwidget">
               <p>Cookies are small text files that are stored by the browser (e.g. Internet Explorer, Chrome, Firefox) on your computer or mobile phone. This site uses anonymous Analytics cookies which allow us to track how many unique individual users we have, and how often they visit the site. Unless a user signs in, these cookies cannot be used to identify an individual; they are used for statistical purposes only. If you are logged in, we will also know the details you gave to us for this, such as username and email address. By continuing to use this site, you are agreeing to the use of cookies.</p>
+              <p><a href="https://www.aidtransparency.net/privacy-policy">Privacy policy</a></p>
             </div>
-          </aside>        
+          </aside>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Change made on advice about what is needed to ensure compliance with new GDPR regulations.

Google analytics tracking is set in the `settings.php` file, stored locally on the server. I have made the required change on the production server - the change can be verified in the `<head>` section of the source of files on http://validator.iatistandard.org